### PR TITLE
Define logo banner image location in zoneboard.json

### DIFF
--- a/css/zoneboard.css
+++ b/css/zoneboard.css
@@ -1752,7 +1752,7 @@
 }
 
 .logo-banner img {
-  max-height: 100%;
+  max-height: 100px;
 }
 
 .wp-menu-name:after {

--- a/css/zoneboard.css
+++ b/css/zoneboard.css
@@ -1747,7 +1747,12 @@
 .logo-banner {
   background-color: #fff;
   margin-left: -20px;
+  max-height: 100px;
   padding: 15px 0 15px 20px;
+}
+
+.logo-banner img {
+  max-height: 100%;
 }
 
 .wp-menu-name:after {

--- a/sass/zoneboard.scss
+++ b/sass/zoneboard.scss
@@ -11,7 +11,7 @@ $zoneboard-green : #004f45;
 }
 
 .logo-banner img {
-  max-height: 100%; 
+  max-height: 100px;
 }
 
 .wp-menu-name {

--- a/sass/zoneboard.scss
+++ b/sass/zoneboard.scss
@@ -6,7 +6,12 @@ $zoneboard-green : #004f45;
 .logo-banner {
   background-color: #fff;
   margin-left: -20px;
+  max-height: 100px;
   padding: 15px 0 15px 20px;
+}
+
+.logo-banner img {
+  max-height: 100%; 
 }
 
 .wp-menu-name {

--- a/views/dashboard.twig
+++ b/views/dashboard.twig
@@ -1,6 +1,6 @@
 <link rel='stylesheet' href='{{stylesheet}}' type='text/css' media='all' />
 	<div class="logo-banner">
-		<img src="/wp-content/plugins/zoneboard/logo.png" />
+		<img src="{{logo_url}}" />
 	</div>
 <div class="wrap">
 	<h2>{{site.name}} Zoneboard</h2>

--- a/zoneboard.json
+++ b/zoneboard.json
@@ -1,4 +1,5 @@
 {
+    "logo_url": "https://raw.githubusercontent.com/jonsherrard/zoneboard/master/logo.png",
     "message" : "Where do you want to start?",
     "bricks" : [
         {

--- a/zoneboard.php
+++ b/zoneboard.php
@@ -92,7 +92,7 @@
 			if ( isset($this->json_data->message )) {
 				$data['message'] = $this->json_data->message;
 			}
-      if ( isset(this->json_data->logo_url )) {
+      if ( isset($this->json_data->logo_url )) {
         $data['logo_url'] = $this->json_data->logo_url;
       }
 			$data['stylesheet'] = plugins_url('css/zoneboard.css', __FILE__);

--- a/zoneboard.php
+++ b/zoneboard.php
@@ -92,6 +92,9 @@
 			if ( isset($this->json_data->message )) {
 				$data['message'] = $this->json_data->message;
 			}
+      if ( isset(this->json_data->logo_url )) {
+        $data['logo_url'] = $this->json_data->logo_url;
+      }
 			$data['stylesheet'] = plugins_url('css/zoneboard.css', __FILE__);
 			foreach($this->vars as $key=>$var){
 				$data[$key] = $var;


### PR DESCRIPTION
Currently Zoneboard looks for the logo-banner image in the plugin directory itself.

I've made an update whereby the zoneboard.json field contains a logo_url field.

