### PR TITLE
Remove call to deprecated TimberHelper::get_current_url() method

### DIFF
--- a/zoneboard.php
+++ b/zoneboard.php
@@ -47,7 +47,7 @@
 				$this->json_data = $json;
 				$this->_bricks = $json->bricks;
 			} else if (is_admin()) {
-				$url = TimberHelper::get_current_url();
+				$url = Timber\URLHelper::get_current_url();
 				$parts = parse_url($url);
 				if ((isset($parts['query']) && $parts['query'] == 'page=zoneboard')
 						|| (isset($parts['path']) && strpos($parts['path'], 'wp-admin/plugins.php'))


### PR DESCRIPTION
The `TimberHelper::get_current_url()` is deprecated and generating notices, so this changes it to use the `Timber\URLHelper::get_current_url()` method.

I use Zoneboard on a few projects, so I don't want it to break when the `TimberHelper::get_current_url()` is removed from Timber!